### PR TITLE
enchilada.xml: fixup-mountpoints should be included for hybris-boot

### DIFF
--- a/enchilada.xml
+++ b/enchilada.xml
@@ -3,6 +3,8 @@
     <!-- Device Parts -->
     <project path="device/oneplus/enchilada" name="LineageOS/android_device_oneplus_enchilada" revision="lineage-16.0" />
     <project path="device/oneplus/sdm845-common" name="sailfish-oneplus6/android_device_oneplus_sdm845-common" revision="lineage-16.0" />
+    <!-- Temporary: Hybris-Boot for fixup-mountpoints -->
+    <project path="hybris/hybris-boot" name="sailfish-oneplus6/hybris-boot" revision="master" />
 
     <!-- libhybris with audio patch -->
     <project path="external/libhybris" name="sailfishos-oneplus5/libhybris" revision="master" />


### PR DESCRIPTION
We should have hybris-boot in enchilada.xml until upstream merges our fixup-mountpoints.