### PR TITLE
enchilada.xml: add hybris-boot

### DIFF
--- a/enchilada.xml
+++ b/enchilada.xml
@@ -4,6 +4,10 @@
     <project path="device/oneplus/enchilada" name="LineageOS/android_device_oneplus_enchilada" revision="lineage-16.0" />
     <project path="device/oneplus/sdm845-common" name="sailfish-oneplus6/android_device_oneplus_sdm845-common" revision="lineage-16.0" />
 
+    <!-- TEMPORARY: until upstream merges our fixup-mountpoints, this is necessary -->
+    <remove-project path="hybris/hybris-boot" name="mer-hybris/hybris-boot"/>
+    <project path="hybris/hybris-boot" name="sailfish-oneplus6/hybris-boot" revision="master" />
+    
     <!-- libhybris with audio patch -->
     <project path="external/libhybris" name="sailfishos-oneplus5/libhybris" revision="master" />
 


### PR DESCRIPTION
For temporary workaround until upstream merges fixup-mountpoints.